### PR TITLE
include video does not survive compress.html

### DIFF
--- a/_includes/video
+++ b/_includes/video
@@ -16,7 +16,7 @@
 {% endcapture %}
 {% assign video_src = video_src | strip %}
 
-<!-- Courtesy of embedresponsively.com //-->
+<!-- Courtesy of embedresponsively.com -->
 {% unless video_src == "" %}
   <div class="responsive-video-container">
     <iframe src="{{ video_src }}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>


### PR DESCRIPTION
This is a bug fix.

## Summary

Using include video in a page breaks when when compress_html is used.  Removed redundant comment in video include file.

## Context

No GitHub issue found.