### PR TITLE
Feature flexible related posts

### DIFF
--- a/_includes/comments-providers/utterances.html
+++ b/_includes/comments-providers/utterances.html
@@ -12,6 +12,7 @@
     script.setAttribute('src', 'https://utteranc.es/client.js');
     script.setAttribute('repo', '{{ site.repository }}');
     script.setAttribute('issue-term', '{{ site.comments.utterances.issue_term | default: "pathname" }}');
+    {% if site.comments.utterances.label %}script.setAttribute('label', '{{ site.comments.utterances.label }}');{% endif %}
     script.setAttribute('theme', '{{ site.comments.utterances.theme | default: "github-light" }}');
     script.setAttribute('crossorigin', 'anonymous');
 

--- a/_includes/related.html
+++ b/_includes/related.html
@@ -1,0 +1,55 @@
+{% assign related_limit = page.related_limit | default: site.related_limit | default: 4 %}
+{% assign related_threshold = page.related_threshold | default: site.related_threshold | default: 0 %}
+{% assign related_template = include.template | default: "archive-single.html" %}
+{% assign related_format = include.format | default: "grid" %}
+
+{% comment %}<!-- Random related pages -->{% endcomment %}
+{% if related_threshold < 0 %}
+  {% assign related_posts = site.documents | sample: related_limit+1 %}
+
+{% comment %}<!-- Tag/category matching pages -->{% endcomment %}
+{% elsif related_threshold > 0 %}
+  {% assign related_posts = "" | split: " " %}
+
+  {% for doc in site.documents %}
+    {% if doc.id == page.id %}
+      {% continue %}
+    {% endif %}
+
+    {% assign related_count = 0 %}
+
+    {% for tag in doc.tags %}
+      {% if page.tags contains tag %}
+        {% assign related_count = related_count | plus: 1 %}
+      {% endif %}
+    {% endfor %}
+
+    {% for cat in doc.categories %}
+      {% if page.categories contains cat %}
+        {% assign related_count = related_count | plus: 1 %}
+      {% endif %}
+    {% endfor %}
+
+    {% if related_count >= related_threshold %}
+      {% assign related_posts = related_posts | push: doc %}
+    {% endif %}
+  {% endfor %}
+
+  {% assign related_posts = related_posts | sample: related_limit %}
+
+{% comment %}<!-- Use site.related_posts for posts if found -->{% endcomment %}
+{% elsif site.related_posts.size > 0 %}
+  {% assign related_posts = site.related_posts %}
+
+{% comment %}<!-- Otherwise show recent posts if no site.related_posts -->{% endcomment %}
+{% else %}
+  {% assign related_posts = site.posts %}
+{% endif %}
+
+{% for post in related_posts limit:related_limit %}
+  {% if post.id == page.id %}
+    {% continue %}
+  {% endif %}
+
+  {% include {{ related_template }} type=related_format %}
+{% endfor %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -64,62 +64,13 @@ layout: default
     {% endif %}
   </article>
 
-  {% comment %}<!-- only show tag/category related posts page when `related: true` -->{% endcomment %}
-  {% assign related_limit = page.related_limit | default: site.related_limit | default: 4 %}
-  {% assign related_threshold = page.related_threshold | default: site.related_threshold | default: 0 %}
-  {% if page.id and page.related and related_threshold > 0 %}
+  {% comment %}<!-- Only show related pages on a page when `related: true` -->{% endcomment %}
+  {% if page.id and page.related %}
     <div class="page__related">
       <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
       <div class="grid__wrapper">
-        {% assign include_count = 0 %}
-        {% assign all = site.documents | concat: site.pages %}
-        {% for post in all %}
-          {% if post.id == page.id %}
-            {% continue %}
-          {% endif %}
-          {% assign related_count = 0 %}
-          {% for tag in post.tags %}
-            {% if page.tag == tag or page.tags contains tag %}
-              {% assign related_count = related_count | plus: 1 %}
-            {% endif %}
-          {% endfor %}
-          {% for cat in post.categories %}
-            {% if page.category == cat or page.categories contains cat %}
-              {% assign related_count = related_count | plus: 1 %}
-            {% endif %}
-          {% endfor %}
-          {% if related_count >= related_threshold %}
-            {% include archive-single.html type="grid" %}
-            {% assign include_count = include_count | plus: 1 %}
-            {% if include_count >= related_limit %}
-              {% break %}
-            {% endif %}
-          {% endif %}
-        {% endfor %}
+        {% include related.html %}
       </div>
     </div>
-  {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}
-  {% elsif page.id and page.related and site.related_posts.size > 0 %}
-    <div class="page__related">
-      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
-      <div class="grid__wrapper">
-        {% for post in site.related_posts limit:related_limit %}
-          {% include archive-single.html type="grid" %}
-        {% endfor %}
-      </div>
-    </div>
-  {% comment %}<!-- otherwise show recent posts if no related when `related: true` -->{% endcomment %}
-  {% elsif page.id and page.related %}
-    <div class="page__related">
-      <h2 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h2>
-      <div class="grid__wrapper">
-        {% for post in site.posts limit:related_limit %}
-          {% if post.id == page.id %}
-            {% continue %}
-          {% endif %}
-          {% include archive-single.html type="grid" %}
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
+  {% endif %}  
 </div>

--- a/docs/_docs/05-configuration.md
+++ b/docs/_docs/05-configuration.md
@@ -423,6 +423,7 @@ comments:
   utterances:
     theme: "github-light" # "github-dark"
     issue_term: "pathname"
+    label: "comment" # Optional - must be existing label.
 ```
 
 #### giscus comments


### PR DESCRIPTION
Flexible related posts option.
related_threshold <0 => random documents
related_threshold =0 => site.related_posts or site.posts
related_threshold >0 => site.documents matched against page tags/categories chosen at random.